### PR TITLE
Change CookieJar field in Session structure to interface http.CookieJar

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	http "github.com/Noooste/fhttp"
-	"github.com/Noooste/fhttp/cookiejar"
 	"github.com/Noooste/fhttp/http2"
 	tls "github.com/Noooste/utls"
 	"io"
@@ -38,7 +37,7 @@ type Session struct {
 	HeaderOrder HeaderOrder
 
 	// Stores cookies across session requests.
-	CookieJar *cookiejar.Jar
+	CookieJar http.CookieJar
 
 	// Name or identifier of the browser used in the session.
 	Browser string


### PR DESCRIPTION
Updated the type of the CookieJar field in the Session structure from `*cookiejar.Jar` to the interface `http.CookieJar` to improve flexibility and allow for custom implementations of CookieJar. This change enhances extensibility and adaptability for various use cases.