### PR TITLE
Update Chrome 132 user agent

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -23,7 +23,7 @@ const (
 	Socks5      = "socks5"
 	Socks5H     = "socks5h"
 
-	defaultUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+	defaultUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36"
 
 	forceHTTP1Key = "force-http1"
 	userAgentKey  = "user-agent"


### PR DESCRIPTION
The default user agent has not been updated after the other bumps. Also a question:
Is there a reason we are not setting the default browser requests as well? I have an access to Mac/Linux/Windows machines and can provide those along the tls fingerprint