### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,6 +2,9 @@ name: build
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Noooste/azuretls-client/security/code-scanning/10](https://github.com/Noooste/azuretls-client/security/code-scanning/10)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Based on the workflow's functionality, it likely only needs `contents: read` to access the repository's code and `pull-requests: write` if it interacts with pull requests. Since the workflow does not modify repository contents, `contents: read` should suffice.

The `permissions` block should be added at the top level of the workflow, just below the `name` field, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
