### PR TITLE
fix chrome quic parameter extension

### DIFF
--- a/examples/http3/http3.go
+++ b/examples/http3/http3.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Noooste/azuretls-client"
 )
@@ -18,7 +19,7 @@ func main() {
 
 	resp, err := session.Do(&azuretls.Request{
 		Method:     "GET",
-		Url:        "https://fp.impersonate.pro/api/http3",
+		Url:        "https://cloudflare-quic.com",
 		ForceHTTP3: true,
 	})
 
@@ -26,6 +27,8 @@ func main() {
 		panic(err)
 	}
 
+	body := string(resp.Body)
+
 	fmt.Println(resp.StatusCode)
-	fmt.Println(string(resp.Body))
+	fmt.Println("HTTP/3:", strings.Contains(body, "your browser used <strong>HTTP/3</strong>"))
 }

--- a/profiles.go
+++ b/profiles.go
@@ -2,6 +2,7 @@ package azuretls
 
 import (
 	"fmt"
+
 	"github.com/Noooste/fhttp/http2"
 	quic "github.com/Noooste/uquic-go"
 	"github.com/Noooste/uquic-go/http3"
@@ -143,30 +144,30 @@ func GetLastChromeVersionForHTTP3() *tls.ClientHelloSpec {
 					tls.InitialMaxStreamsUni(103),
 					tls.MaxIdleTimeout(30000),
 					tls.InitialMaxData(15728640),
-					tls.InitialMaxStreamDataUni(0x80600000),
+					tls.InitialMaxStreamDataUni(6291456),
 					&tls.VersionInformation{
 						ChoosenVersion: tls.VERSION_1,
 						AvailableVersions: []uint32{
 							tls.VERSION_GREASE,
 							tls.VERSION_1,
 						},
-						LegacyID: true,
+						LegacyID: false,
 					},
 					&tls.FakeQUICTransportParameter{ // google_quic_version
 						Id:  0x4752,
 						Val: []byte{00, 00, 00, 01}, // Google QUIC version 1
 					},
 					&tls.FakeQUICTransportParameter{ // google_connection_options
-						Id:  0x3127,
-						Val: []byte{0x80, 0x03, 0xe4, 0x2e},
+						Id:  0x3128,
+						Val: []byte{0x42, 0x32, 0x4f, 0x4e}, // = B2ON
 					},
 					tls.MaxDatagramFrameSize(65536),
 					tls.InitialMaxStreamsBidi(100),
-					tls.InitialMaxStreamDataBidiLocal(0x80600000),
+					tls.InitialMaxStreamDataBidiLocal(6291456),
 					quic.VariableLengthGREASEQTP(0x10), // Random length for GREASE QTP
 					tls.InitialSourceConnectionID([]byte{}),
 					tls.MaxUDPPayloadSize(1472),
-					tls.InitialMaxStreamDataBidiRemote(0x80600000),
+					tls.InitialMaxStreamDataBidiRemote(6291456),
 				},
 			}),
 			&tls.ApplicationSettingsExtensionNew{


### PR DESCRIPTION
- fixed invalid max stream data bidi * (was varint value instead of the actual uint)
- use version information RFC-assigned id instead of the legacy one (that's what Chrome does)
- changed google_connection_options ID to the actual correct one (previously was google initial rtt which seems to be optional, although it should be debugged furthermore as I sometimes manage to see google_initial_rtt sent but not google_connection_options, both have also "dynamic" content)
- updated h3 test url to cloudflare-quic.com as it seems like at least for me that fp.impersonate.pro does not want to dial over h3 at all currently

![image](https://github.com/user-attachments/assets/237fafef-0ccc-44f9-b02f-385d1004a934)
