### PR TITLE
feat: change preHook and callback to more middleware-like

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -1,0 +1,9 @@
+package azuretls
+
+func (s *Session) UseCallbackWithContext(callback func(ctx *Context)) {
+	s.CallbacksWithContext = append(s.CallbacksWithContext, callback)
+}
+
+func (s *Session) UsePrehookWithContext(preHook func(ctx *Context) error) {
+	s.PreHooksWithContext = append(s.PreHooksWithContext, preHook)
+}

--- a/request.go
+++ b/request.go
@@ -42,11 +42,15 @@ func (s *Session) prepareRequest(request *Request, args ...any) error {
 
 	s.fillEmptyValues(request)
 
-	if s.PreHookWithContext != nil {
-		return s.PreHookWithContext(&Context{
-			Session: s,
-			Request: request,
-		})
+	if len(s.PreHooksWithContext) > 0 {
+		for _, hook := range s.PreHooksWithContext {
+			if err := hook(&Context{
+				Session: s,
+				Request: request,
+			}); err != nil {
+				return err
+			}
+		}
 	}
 
 	if s.PreHook != nil {

--- a/session.go
+++ b/session.go
@@ -98,7 +98,7 @@ func (s *Session) send(request *Request) (response *Response, err error) {
 			s.Callback(request, response, err)
 		}
 
-		if s.CallbackWithContext != nil {
+		if len(s.CallbacksWithContext) > 0 {
 			c := &Context{
 				Session:          s,
 				Request:          request,
@@ -108,7 +108,13 @@ func (s *Session) send(request *Request) (response *Response, err error) {
 				RequestStartTime: request.startTime,
 			}
 
-			s.CallbackWithContext(c)
+			for _, callback := range s.CallbacksWithContext {
+				callback(c)
+
+				if c.Err != nil {
+					break
+				}
+			}
 
 			err = c.Err
 			response = c.Response
@@ -311,12 +317,14 @@ func (s *Session) do(req *Request, args ...any) (resp *Response, err error) {
 				req.OrderedHeaders.Del("Content-Type")
 			}
 
-			if s.PreHookWithContext != nil {
-				if err = s.PreHookWithContext(&Context{
-					Session: s,
-					Request: req,
-				}); err != nil {
-					return nil, err
+			if len(s.PreHooksWithContext) > 0 {
+				for _, hook := range s.PreHooksWithContext {
+					if err = hook(&Context{
+						Session: s,
+						Request: req,
+					}); err != nil {
+						return nil, err
+					}
 				}
 			}
 

--- a/structs.go
+++ b/structs.go
@@ -80,13 +80,13 @@ type Session struct {
 	// Deprecated, use PreHookWithContext instead.
 	PreHook func(request *Request) error
 	// Function called before sending a request.
-	PreHookWithContext func(ctx *Context) error
+	PreHooksWithContext []func(ctx *Context) error
 
 	// Deprecated, use CallbackWithContext instead.
 	Callback func(request *Request, response *Response, err error)
 
 	// Function called after receiving a response.
-	CallbackWithContext func(ctx *Context)
+	CallbacksWithContext []func(ctx *Context)
 
 	// Function to modify the dialer used for establishing connections.
 	ModifyDialer func(dialer *net.Dialer) error


### PR DESCRIPTION
I feel like current implementation isn't the best, and requires your own additional wrappers if you want to register more than one middleware (either prehook or callback).